### PR TITLE
Clarify speed meaning and handle speed == 0

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -168,7 +168,7 @@ function Application() {
     var runButton = new Button("Run", app.startSimulation);
     var stopButton = new Button("Stop", app.stopSimulation);
     var resetButton = new Button("Reset", app.resetSimulation);
-    var speedLabel = new Span("Speed:");
+    var speedLabel = new Span("Steps/sec:");
     var speedInput = new ModelInput(app.model, "speed");
     
     var buttons = document.getElementById("buttons");
@@ -346,6 +346,13 @@ function Application() {
     app.stopSimulation();
 
     var speed = parseInt(app.model.get("speed"));
+    if (speed < 0) {
+      return;
+    }
+    if (speed === 0) {
+      speed = 100000;
+    }
+
     if (speed <= 30) {
       // do one step per call, and call each 1/speed seconds
       app.timer = setInterval(app.runSimulationSteps(1), 1000 / speed);


### PR DESCRIPTION
Hi, @yozw!

Love your Markov Chain simulator (and yes, I know that the last update was 9 years ago).
I recently encountered an issue and wanted to make things easier for other people that randomly find this tool.

So I misunderstood the "speed" parameter and thought that 0 was a valid value (it produces adequate results on the default example). However this yields wrong results on some different inputs i.e. this one

Transition probabilities            |  Graphical representation
:-------------------------:|:-------------------------:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/32249492/236650607-0adafaa7-d86b-4cc0-bd16-d0ff26c8c48a.png">  |  <img width="402" alt="image" src="https://user-images.githubusercontent.com/32249492/236650603-fff20907-8eda-420d-b10e-717bc6836c02.png">

This happens because it is considered slow speed by your code (`if (speed <= 30)`) and uses different logic which behaves strangely on high speed and sometimes sets the state to `4` which must be impossible.

I could fix the inaccurate behaviour but the simpler solution would be the one below: clarify that the speed means steps per second and also set the speed to a high number (100000 is good enough) when 0 is plugged in for people like me not to surprised by the wrong behaviour.
